### PR TITLE
Keep copy of libBamM.a in bamm folder for testing purposes

### DIFF
--- a/bamm/cWrapper.py
+++ b/bamm/cWrapper.py
@@ -451,6 +451,7 @@ class CWrapper:
         # load the c library
         #---------------------------------
         c_lib = os.path.abspath(resource_filename('bamm', 'libBamM.a'))
+        print c_lib
         if UT:
             # unit tests are run from within the install dir which confuses
             # pkg_resources as there is a folder there called bamm
@@ -459,6 +460,7 @@ class CWrapper:
                 for d in dist:
                     if d == 'bamm':
                         c_lib = os.path.join(dist_path, d, 'libBamM.a')
+                        print c_lib
 
         try:
             self.libPMBam = c.cdll.LoadLibrary(c_lib)

--- a/bamm/cWrapper.py
+++ b/bamm/cWrapper.py
@@ -451,7 +451,6 @@ class CWrapper:
         # load the c library
         #---------------------------------
         c_lib = os.path.abspath(resource_filename('bamm', 'libBamM.a'))
-        print c_lib
         if UT:
             # unit tests are run from within the install dir which confuses
             # pkg_resources as there is a folder there called bamm
@@ -460,7 +459,6 @@ class CWrapper:
                 for d in dist:
                     if d == 'bamm':
                         c_lib = os.path.join(dist_path, d, 'libBamM.a')
-                        print c_lib
 
         try:
             self.libPMBam = c.cdll.LoadLibrary(c_lib)

--- a/bamm/tests/modeling/makeTestData.py
+++ b/bamm/tests/modeling/makeTestData.py
@@ -63,7 +63,8 @@ contigs = {'A':[17, '', {'PE':[], 'MP':[], 'UP':[]}, {'PE':0, 'MP':0, 'UP':0}],
            'C':[17, '', {'PE':[], 'MP':[], 'UP':[]}, {'PE':0, 'MP':0, 'UP':0}],
            'E':[16, '', {'PE':[], 'MP':[], 'UP':[]}, {'PE':0, 'MP':0, 'UP':0}],
            'Z':[17, '', {'PE':[], 'MP':[], 'UP':[]}, {'PE':0, 'MP':0, 'UP':0}]}
-
+           
+           
 # the reads we make
 pe= []
 mp = []
@@ -98,6 +99,8 @@ out_fnames = {'PE': ["pe.1.fa", "pe.2.fa"], # coupled
 bam_fnames = {'PE': "contigs.pe.1",         # the .1 remains
               'MP': "contigs.mp",
               'UP': "contigs.up"}
+              
+bad_contigs_filename = "contigs_bad.fa"
 
 ###############################################################################
 ###############################################################################
@@ -157,6 +160,7 @@ def doWork( args ):
         except:
             print "Error opening file:", group_name, sys.exc_info()[0]
             raise
+        
 
     # parse fasta file
     seq = []
@@ -484,6 +488,12 @@ def doWork( args ):
     with open(os.path.join(args.outdir, out_fnames['UP']), "w") as up_fh:
         for (rid, r1) in up:
             up_fh.write(">%s_UP\n%s\n" % (rid, r1))
+            
+    if args.bad:        
+        with open(os.path.join(args.outdir, bad_contigs_filename), "w") as bad_con_fh:
+            for cid in contigs.keys():
+                if cid != 'Z':
+                    bad_con_fh.write(">%s\n%s\n" % ('AA', contigs[cid][1]))
 
     return 0
 
@@ -498,6 +508,7 @@ if __name__ == '__main__':
     parser.add_argument('-r', '--readkey', help="describes how reads should be made")
     parser.add_argument('-f', '--fasta', help="fasta file to cut contigs from")
     parser.add_argument('-g', '--groups', nargs='+', help="groups files")
+    parser.add_argument('--bad', action="store_true", help="simulate invalid reference input")
     parser.add_argument('-o',
                         '--outdir',
                         default='.',

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ setup(
 )
 
 # remove the library
-to_remove = join('bamm', 'libBamM.a') 
-if exists(to_remove):
-    remove(to_remove)
+#to_remove = join('bamm', 'libBamM.a') 
+#if exists(to_remove):
+#    remove(to_remove)


### PR DESCRIPTION
Running nosetests from the repository root will now work as the imported bamm module contains the built c object.